### PR TITLE
Fix security warnings on GitHub Actions

### DIFF
--- a/.github/workflows/__create_gh_release_notes.yml
+++ b/.github/workflows/__create_gh_release_notes.yml
@@ -21,6 +21,11 @@ on:
         default: '_release_notes'
         description: "Optional: _release_notes by default"
 
+# Default permissions
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # Ensure that we run on tag references only
   job1_Validate_Tag_Reference:

--- a/.github/workflows/__maven_clean_deploy.yml
+++ b/.github/workflows/__maven_clean_deploy.yml
@@ -50,6 +50,11 @@ on:
         description: "The Maven version job1 was run on"
         value: ${{ jobs.job1_Build_and_Deploy.outputs.MAVEN_VERSION }}
 
+# Default permissions
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   job1_Build_and_Deploy:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/__maven_unleash.yml
+++ b/.github/workflows/__maven_unleash.yml
@@ -71,6 +71,11 @@ on:
         description: "The next development version having been applied"
         value: ${{ jobs.job1_Unleash_Project.outputs.EFFECTIVE_NEXT_SNAPSHOT_VERSION }}
 
+# Default permissions
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   job1_Unleash_Project:
     runs-on: ${{ inputs.runner }}


### PR DESCRIPTION
# Changes
- __create_gh_release_notes.yml, __maven_clean_deploy.yml, __maven_unleash.yml:
  - add (explicit) default permissions:
    - contents: read
    - pull-requests: write

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to use explicit, least-privilege default permissions for the GitHub token (read for contents, write for pull requests).
  * Standardized permissions configuration across reusable and deployment workflows without altering job steps or logic.
  * Improves safety and consistency of automated release and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->